### PR TITLE
Fix issue with blue-green deployments using istio

### DIFF
--- a/000-default.conf
+++ b/000-default.conf
@@ -9,15 +9,16 @@
 	ErrorLog ${APACHE_LOG_DIR}/error.log
 	CustomLog ${APACHE_LOG_DIR}/access.log combined
 
-	ProxyPreserveHost On
+        # do not use proxy preserve host together with istio
+	# ProxyPreserveHost On
 
-        ProxyPass        /order http://order:${SERVICES_PORT}/
-        ProxyPassReverse /order http://order:${SERVICES_PORT}/
+        ProxyPass        /order/ http://order:${SERVICES_PORT}/
+        ProxyPassReverse /order/ http://order:${SERVICES_PORT}/
 
-        ProxyPass        /catalog http://catalog:${SERVICES_PORT}/
-        ProxyPassReverse /catalog http://catalog:${SERVICES_PORT}/
+        ProxyPass        /catalog/ http://catalog:${SERVICES_PORT}/
+        ProxyPassReverse /catalog/ http://catalog:${SERVICES_PORT}/
 
-        ProxyPass        /customer http://customer:${SERVICES_PORT}/
-        ProxyPassReverse /customer http://customer:${SERVICES_PORT}/
+        ProxyPass        /customer/ http://customer:${SERVICES_PORT}/
+        ProxyPassReverse /customer/ http://customer:${SERVICES_PORT}/
 
 </VirtualHost>


### PR DESCRIPTION
When `ProxyPreserveHost` is set to on, Apache2 will set the `Host` header to `frontend`, which the istio proxy will resolve as the frontend service.

By not setting this option, Apache2 will set the `Host` header to the service that you are trying to proxy (e.g., `customer`).